### PR TITLE
vscode refactor

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,24 @@
+{
+    // For viewing the settings in `json` format
+    "workbench.settings.editor": "json",
+    // Setting the python path to the python installed in the environment `mle-dev`
+    "python.defaultInterpreterPath": "~/miniconda3/envs/mle-dev/bin/python",
+    // Configuring isort and black
+    "python.sortImports.args": [
+        "--profile",
+        "black"
+    ],
+    // To run auto-formatter(black) everytime we save the file
+    "editor.formatOnSave": true,
+    // Organise imports everytime we save the file
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    },
+    // Configuring flake8 and black
+    "python.linting.flake8Args": [
+        "--max-line-length",
+        "88",
+        "--extend-ignore",
+        "E203"
+    ]
+}


### PR DESCRIPTION
Auto formatting settings are done in `.json` via VS-Code shown in `settings.json` for review (shown below)
close #6
Python Path
```
"python.defaultInterpreterPath": "~/miniconda3/envs/mle-dev/bin/python"
```
To run auto-formatter on save
```
"editor.formatOnSave": true
```
Sort imports on save
```
"editor.codeActionsOnSave": {
        "source.organizeImports": true
    }
```
Custom parameters for `isort`
```
"python.sortImports.args": [
        "--profile",
        "black"
    ]
```
Custom parameters for `flake8`
```
"python.linting.flake8Args": [
        "--max-line-length",
        "88",
        "--extend-ignore",
        "E203"
    ]
```

